### PR TITLE
Support new option { :quiet => true } to silence STDOUT output

### DIFF
--- a/lib/mockingbird.rb
+++ b/lib/mockingbird.rb
@@ -23,6 +23,7 @@ module Mockingbird
     # Options are
     #   :host - The host to listen on. 0.0.0.0 by default
     #   :port - The port to listen on. 4879 by default
+    #   :quiet - Silence debug-output. Default is to be verbose
     #
     # The block is a Mockingbird configuration (see README).
     def setup(opts={},&block)
@@ -33,7 +34,7 @@ module Mockingbird
         Server.start!(opts)
       end
       Process.detach(@pid)
-      puts "Waiting for Mockingbird to start..."
+      puts "Waiting for Mockingbird to start..." unless opts[:quiet]
       sleep(1) # Necessary to make sure the forked proc is up and running
       @pid
     end

--- a/lib/mockingbird/server.rb
+++ b/lib/mockingbird/server.rb
@@ -23,7 +23,7 @@ module Mockingbird
         host = opts[:host]
         port = opts[:port]
         EventMachine::run do
-          puts "Mockingbird is mocking you on #{host}:#{port} (pid=#{$$})"
+          puts "Mockingbird is mocking you on #{host}:#{port} (pid=#{$$})" unless opts[:quiet]
           EventMachine::start_server host, port, self
         end
       end


### PR DESCRIPTION
Tiny patch to disable the "puts" text when desired.

Having this info on by default is convenient, but it's also nice to be able to switch it off.
## 

Regards
Laust Rud
http://object.io
